### PR TITLE
docs(README): Clean up formatting + typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Usage example for [goreleaser-cross](https://github.com/goreleaser/goreleaser-cross)
 
 ## Whats inside
-Demonstrate how to cross-compile Go project with CGO dependencies
-Project depends on C/C++ libraries `libftdi1, libusb-1.0, opencv4`
-Executable is trying to detect FTDI 2232 boards with VID: 0x0403 and PID: 0x6010 and open channel 0.
-It lists serial number of all detected boards. 
-Afterwards it is trying to open camera with OpenCV and make test picture into your terminal
+Demonstrates how to cross-compile Go project with CGO dependencies.
+Project depends on C/C++ libraries `libftdi1, libusb-1.0, opencv4`.
+- Executable will try to detect FTDI 2232 boards with VID: 0x0403 and PID: 0x6010 and open channel 0.
+- Then it lists serial number of all detected boards. 
+- Afterwards it will try to open camera with OpenCV and take test picture into your terminal
 
 Example of output
 ```
@@ -25,10 +25,9 @@ Cross-compiles for targets:
  - Linux/armhf (Raspberry Pi 4 aka RPI4)
  - Linux/amd64 (should not be any issue to add this example)
 
-This example is based on real working solution where Macbook is dev machine and RPI4 is end target
-Cross-compilation is set for both darwin and linux to ensure nothing is broken with new commits
+This example is based on real working solution where Macbook is dev machine and RPI4 is end target. Cross-compilation is set for both darwin and linux to ensure nothing is broken with new commits
  
 ## Sysroot
 Sysroots are located in [separate repo](https://github.com/goreleaser/goreleaser-cross-example-sysroot) and added as submodule to current repo 
-**Darwin** sysroot is created by simply copying libraries from `homebrew`
-**Linux** sysroot is created from RPI4 using [this script](https://github.com/goreleaser/goreleaser-cross/blob/master/scripts/sysroot-rsync.sh)
+- **Darwin** sysroot is created by simply copying libraries from `homebrew`
+- **Linux** sysroot is created from RPI4 using [this script](https://github.com/goreleaser/goreleaser-cross/blob/master/scripts/sysroot-rsync.sh)


### PR DESCRIPTION
Cleaned up some of the lines where Markdown wasn't putting in a linebreak to make the seperated items a bit clearer.