### PR TITLE
chore: replace usage of deprecated Docker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ release-dry-run:
 		-v `pwd`/sysroot:/sysroot \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--rm-dist --skip-validate --skip-publish
+		--clean --skip=validate --skip=publish
 
 .PHONY: release
 release:

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ release:
 		-v `pwd`/sysroot:/sysroot \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --rm-dist
+		release --clean


### PR DESCRIPTION
Closes https://github.com/goreleaser/goreleaser-cross-example/issues/9

When I run this PR locally, I no longer observe the deprecation notices.